### PR TITLE
Update schedule to 5am UTC start

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,7 +1,7 @@
 services:
   - name: backup-db
     type: cron
-    schedule: "0 3 * * *"
+    schedule: "0 5 * * *"
     region: oregon
     env: docker
     plan: standard
@@ -15,7 +15,7 @@ services:
       # pick the region closest to your database
       # For example, us-west-2 for the Oregon region
       - key: AWS_REGION
-        sync: false 
+        sync: false
       # A globally unique name for your bucket
       # For example, <your-username>-<database name>-render-postgres-backups
       - key: S3_BUCKET_NAME
@@ -25,8 +25,7 @@ services:
         sync: false
       - key: AWS_SECRET_ACCESS_KEY
         sync: false
-      # Postgres version of your Postgres instance 
+      # Postgres version of your Postgres instance
       # For example, 14
       - key: POSTGRES_VERSION
         value: 15
-


### PR DESCRIPTION
As discussed in Slack [here](https://feltmaps.slack.com/archives/C02SZ1NSTCJ/p1739331102283239).

The job currently takes ~2.5 hours to run – start/end times by Felt-relevant time zones as follows:
- 5-7:30am UTC
- 6-8:30am CET (Spain)
- 12-2:30am ET
- 9-11:30pm PT